### PR TITLE
Adapt to gleam_erlang and gleam_stdlib atom/dynamic APIs

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -7,8 +7,10 @@ repository = { type = "github", user = "grottohub", repo = "carpenter" }
 links = [{ title = "Website", href = "https://github.com/grottohub/carpenter" }]
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
-gleam_erlang = "~> 0.24"
+gleam_erlang = ">= 1.3.0 and < 2.0.0"
+gleam_stdlib = ">= 0.70.0 and < 1.0.0"
+
+
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
+  { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
 ]
 
 [requirements]
-gleam_erlang = { version = "~> 0.24" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_erlang = { version = ">= 1.3.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.70.0 and < 1.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/src/carpenter/table.gleam
+++ b/src/carpenter/table.gleam
@@ -93,33 +93,31 @@ fn privacy_prop(prop: Privacy) -> dynamic.Dynamic {
     Protected -> "protected"
     Public -> "public"
   }
-  |> atom.create_from_string
-  |> dynamic.from
+  |> atom.create
+  |> atom.to_dynamic
 }
 
 fn write_concurrency_prop(prop: WriteConcurrency) -> dynamic.Dynamic {
-  case prop {
-    WriteConcurrency -> "true"
-    NoWriteConcurrency -> "false"
-    AutoWriteConcurrency -> "auto"
+  let value = case prop {
+    WriteConcurrency -> atom.create("true")
+    NoWriteConcurrency -> atom.create("false")
+    AutoWriteConcurrency -> atom.create("auto")
   }
-  |> atom.create_from_string
-  |> fn(x) { #(atom.create_from_string("write_concurrency"), x) }
-  |> dynamic.from
+  dynamic.array([
+    atom.create("write_concurrency") |> atom.to_dynamic,
+    atom.to_dynamic(value),
+  ])
 }
 
 fn build_table(
   builder: TableBuilder(k, v),
   table_type: String,
 ) -> Result(atom.Atom, Nil) {
-  let name = atom.create_from_string(builder.name)
+  let name = atom.create(builder.name)
 
   let props =
-    [
-      atom.create_from_string(table_type),
-      atom.create_from_string("named_table"),
-    ]
-    |> list.map(dynamic.from)
+    [atom.create(table_type), atom.create("named_table")]
+    |> list.map(atom.to_dynamic)
 
   let props = case builder.privacy {
     Some(x) -> [privacy_prop(x), ..props]
@@ -133,8 +131,10 @@ fn build_table(
 
   let props = case builder.read_concurrency {
     Some(x) -> [
-      #(atom.create_from_string("read_concurrency"), x)
-        |> dynamic.from,
+      dynamic.array([
+        atom.create("read_concurrency") |> atom.to_dynamic,
+        dynamic.bool(x),
+      ]),
       ..props
     ]
     _ -> props
@@ -142,18 +142,13 @@ fn build_table(
 
   let props = case builder.compressed {
     True -> [
-      atom.create_from_string("compressed")
-        |> dynamic.from,
+      atom.create("compressed") |> atom.to_dynamic,
       ..props
     ]
     False -> props
   }
 
-  ets_bindings.new_table(
-    name,
-    props
-      |> list.map(dynamic.from),
-  )
+  ets_bindings.new_table(name, props)
 }
 
 /// Specify table as a `set`
@@ -229,7 +224,7 @@ pub fn contains(set: Set(k, v), key: k) -> Bool {
 
 /// Get a reference to an existing table
 pub fn ref(name: String) -> Result(Set(k, v), Nil) {
-  case atom.from_string(name) {
+  case atom.get(name) {
     Ok(t) -> Ok(Set(Table(t)))
     Error(_) -> Error(Nil)
   }


### PR DESCRIPTION
- Replace atom.create_from_string/create_from_string-style usage with atom.create
- Use atom.get for table refs (formerly from_string)
- Build ETS option terms with atom.to_dynamic, dynamic.bool, and dynamic.array instead of removed dynamic.from
- Drop redundant dynamic wrapping of the props list passed to new_table